### PR TITLE
HTTP handlers middleware

### DIFF
--- a/spec/prometheus/client/registry_spec.cr
+++ b/spec/prometheus/client/registry_spec.cr
@@ -108,4 +108,41 @@ describe Prometheus::Client::Registry do
       end
     end
   end
+
+  describe "#counter" do
+    it "should return a Prometheus::Client::Counter" do
+      with_registry do |registry|
+        counter = registry.counter(:foo, "lorem ipsum", {:bar => "baz"})
+        counter.should be_a(Prometheus::Client::Counter)
+        counter.name.should eq(:foo)
+        counter.docstring.should eq("lorem ipsum")
+        counter.base_labels.should eq({:bar => "baz"})
+      end
+    end
+  end
+
+  describe "#gauge" do
+    it "should return a Prometheus::Client::Gauge" do
+      with_registry do |registry|
+        gauge = registry.gauge(:foo, "lorem ipsum", {:bar => "baz"})
+        gauge.should be_a(Prometheus::Client::Gauge)
+        gauge.name.should eq(:foo)
+        gauge.docstring.should eq("lorem ipsum")
+        gauge.base_labels.should eq({:bar => "baz"})
+      end
+    end
+  end
+
+  describe "#histogram" do
+    it "should return a Prometheus::Client::Histogram" do
+      with_registry do |registry|
+        histogram = registry.histogram(:foo, "lorem ipsum", {:bar => "baz"}, [0.5, 1.0, 2.0])
+        histogram.should be_a(Prometheus::Client::Histogram)
+        histogram.name.should eq(:foo)
+        histogram.docstring.should eq("lorem ipsum")
+        histogram.base_labels.should eq({:bar => "baz"})
+        histogram.buckets.should eq([0.5, 1.0, 2.0])
+      end
+    end
+  end
 end

--- a/spec/prometheus/http/handlers/collector_spec.cr
+++ b/spec/prometheus/http/handlers/collector_spec.cr
@@ -62,7 +62,7 @@ describe Prometheus::HTTP::Handlers::Collector do
     request = HTTP::Request.new("GET", "/foo")
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
-    registry = Prometheus::Client.registry
+    registry = Prometheus::Client::Registry.new
 
     handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
     handler.next = ->(ctx : HTTP::Server::Context) do

--- a/spec/prometheus/http/handlers/collector_spec.cr
+++ b/spec/prometheus/http/handlers/collector_spec.cr
@@ -1,0 +1,78 @@
+require "spec"
+require "http/server"
+require "../../../../src/prometheus/http/handlers/collector"
+
+describe Prometheus::HTTP::Handlers::Collector do
+  describe ".new" do
+    it "should use the default registry" do
+      handler = Prometheus::HTTP::Handlers::Collector.new
+
+      handler.registry.should eq(Prometheus::Client.registry)
+    end
+
+    it "should allow a custom registry" do
+      registry = Prometheus::Client::Registry.new
+      handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
+      handler.registry.should eq(registry)
+      handler.registry.should_not eq(Prometheus::Client.registry)
+    end
+
+    it "should create an HTTP request counter named http_requests_total" do
+      registry = Prometheus::Client::Registry.new
+      handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
+      registry.get(:http_requests_total).should be_a(Prometheus::Client::Counter)
+    end
+
+    it "should create an exceptions counter named http_exceptions_total" do
+      registry = Prometheus::Client::Registry.new
+      handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
+      registry.get(:http_exceptions_total).should be_a(Prometheus::Client::Counter)
+    end
+
+    it "should create an HTTP request durations histogram named http_request_duration_total_milliseconds" do
+      registry = Prometheus::Client::Registry.new
+      handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
+      handler.registry.should eq(registry)
+      handler.registry.should_not eq(Prometheus::Client.registry)
+      registry.get(:http_request_duration_total_milliseconds).should be_a(Prometheus::Client::Histogram)
+    end
+  end
+
+  it "should return the app response" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/")
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+
+    called = false
+    handler = Prometheus::HTTP::Handlers::Collector.new(registry: Prometheus::Client::Registry.new)
+    handler.next = ->(ctx : HTTP::Server::Context) do
+      called = true
+      ctx.response.status_code = 201
+      ctx.response.print "OK"
+    end
+    handler.call(context)
+
+    called.should be_true
+    context.response.status_code.should eq(201)
+  end
+
+  it "traces request information" do
+    io = IO::Memory.new
+    request = HTTP::Request.new("GET", "/foo")
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    registry = Prometheus::Client.registry
+
+    handler = Prometheus::HTTP::Handlers::Collector.new(registry: registry)
+    handler.next = ->(ctx : HTTP::Server::Context) do
+      ctx.response.status_code = 201
+      ctx.response.print "OK"
+    end
+    handler.call(context)
+
+    registry.get(:http_requests_total)
+            .get({:method => "GET", :path => "/foo", :code => "201"})
+            .should eq(1.0)
+  end
+end

--- a/src/prometheus/client/registry.cr
+++ b/src/prometheus/client/registry.cr
@@ -42,6 +42,18 @@ module Prometheus
       def histogram(name, docstring, base_labels, buckets)
         register(Prometheus::Client::Histogram.new(name, docstring, base_labels, buckets))
       end
+
+      def counter(name, docstring, base_labels)
+        register(Prometheus::Client::Counter.new(name, docstring, base_labels))
+      end
+
+      def gauge(name, docstring, base_labels)
+        register(Prometheus::Client::Gauge.new(name, docstring, base_labels))
+      end
+
+      def histogram(name, docstring, base_labels, buckets)
+        register(Prometheus::Client::Histogram.new(name, docstring, base_labels, buckets))
+      end
     end
   end
 end

--- a/src/prometheus/http/handlers/collector.cr
+++ b/src/prometheus/http/handlers/collector.cr
@@ -1,0 +1,58 @@
+require "http/server"
+require "../../client"
+
+module Prometheus
+  module HTTP
+    module Handlers
+      class Collector
+        include ::HTTP::Handler
+
+        property registry
+
+        @requests : Prometheus::Client::Counter
+        @exceptions : Prometheus::Client::Counter
+        @durations : Prometheus::Client::Histogram
+
+        def initialize(@registry : Prometheus::Client::Registry = Prometheus::Client.registry)
+          base_labels = {} of Symbol => String
+
+          @requests = registry.counter(
+            :http_requests_total,
+            "The total number of HTTP requests handled by the application.",
+            base_labels
+          )
+
+          @exceptions = registry.counter(
+            :http_exceptions_total,
+            "The total number of exceptions raised by the application.",
+            base_labels
+          )
+
+          @durations = registry.histogram(
+            :http_request_duration_total_milliseconds,
+            "The HTTP response duration of the application.",
+            base_labels,
+            Prometheus::Client::Histogram::DEFAULT_BUCKETS
+          )
+        end
+
+        def call(ctx : ::HTTP::Server::Context)
+          trace(ctx) { call_next(ctx) }
+        end
+
+        private def trace(ctx : ::HTTP::Server::Context)
+          start = Time.now
+          yield.tap do
+            @requests.increment(
+              {
+                :code   => ctx.response.status_code.to_s,
+                :method => ctx.request.method.upcase,
+                :path   => ctx.request.path,
+              }
+            )
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR will add the equivalent of Ruby's `Prometheus::Middleware::Collector` and `Prometheus::Middleware::Exporter`.